### PR TITLE
Fix: Remove persistent disk configuration for Cloud SQL-only setup

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -69,7 +69,3 @@ services:
         sync: false  # Set manually in Render dashboard
       - key: N8N_SMTP_PASS
         sync: false  # Set manually in Render dashboard
-    disk:
-      name: n8n-data
-      mountPath: /home/node/.n8n
-      sizeGB: 5


### PR DESCRIPTION
## Summary
- Remove persistent disk configuration from render.yaml
- Rely purely on Google Cloud SQL for all data persistence
- Fix n8n data persistence issues on Render starter plan

## Problem
The current configuration specified a persistent disk but used a starter plan that doesn't support persistent disks. This caused n8n to not persist workflow data properly.

## Solution
Remove the disk configuration entirely since we're using Google Cloud SQL for database storage. This eliminates the need for local file persistence and works with the starter plan.

## Test plan
- [ ] Deploy to Render and verify n8n starts successfully
- [ ] Create a test workflow and verify it persists after service restart
- [ ] Confirm no disk-related errors in service logs

🤖 Generated with [Claude Code](https://claude.ai/code)