### PR TITLE
Fix: Make N8N_ENCRYPTION_KEY persistent across deployments

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,7 +14,7 @@ services:
       - key: N8N_BASIC_AUTH_PASSWORD
         generateValue: true
       - key: N8N_ENCRYPTION_KEY
-        generateValue: true
+        sync: false  # Set manually in Render dashboard - MUST persist across deployments!
       - key: N8N_HOST
         fromService:
           type: web


### PR DESCRIPTION
## Summary
- Change N8N_ENCRYPTION_KEY from `generateValue: true` to `sync: false`
- Fixes n8n treating every deployment as fresh installation
- Prevents loss of encrypted credentials and user settings

## Problem
The current configuration regenerates the encryption key on every deployment, making existing encrypted data unreadable. This causes:
- Admin user recreation required after each deploy
- Loss of saved credentials
- Workflows losing encrypted connection data

## Solution
Set encryption key to manual configuration (`sync: false`) so it persists across deployments.

## Test plan
- [ ] Deploy and verify encryption key remains stable
- [ ] Create admin user once and verify it persists after redeployment
- [ ] Test workflow credentials remain accessible

🤖 Generated with [Claude Code](https://claude.ai/code)