### PR TITLE
feat: reduce health check frequency to 5 minutes for cost optimization

### DIFF
--- a/cloud-run-deployment.yaml
+++ b/cloud-run-deployment.yaml
@@ -165,6 +165,6 @@ spec:
             path: /
             port: 8080
           initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 300
           timeoutSeconds: 10
           failureThreshold: 3


### PR DESCRIPTION
## Summary
- Changed liveness probe interval from 30 seconds to 5 minutes (300 seconds)
- Reduces unnecessary probe traffic for proof-of-concept deployment
- Allows Cloud Run service to scale down more frequently between checks

## Test plan
- [ ] Deploy to Cloud Run and verify service remains stable
- [ ] Monitor cost reduction over time
- [ ] Confirm service still restarts on actual failures

🤖 Generated with [Claude Code](https://claude.ai/code)