### PR TITLE
fix: correct startup script path in Dockerfile.cloudrun

### DIFF
--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -14,7 +14,7 @@ RUN mkdir -p /home/node/.n8n && chown -R node:node /home/node/.n8n
 RUN mkdir -p /scripts && chown -R node:node /scripts
 
 # Copy startup script
-COPY cloud-run-startup.sh /scripts/startup.sh
+COPY scripts/cloud-run-startup.sh /scripts/startup.sh
 RUN chmod +x /scripts/startup.sh && chown node:node /scripts/startup.sh
 
 # Switch back to node user


### PR DESCRIPTION
## Summary
- Fixed incorrect path in Dockerfile.cloudrun COPY command
- The startup script was being copied from wrong location causing build failures
- Updated to reference `scripts/cloud-run-startup.sh` instead of `cloud-run-startup.sh`

## Test plan
- [x] Docker build completes successfully
- [ ] Cloud Run deployment works without build errors

🤖 Generated with [Claude Code](https://claude.ai/code)