### PR TITLE
chore: migrate to AWS RDS and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The project uses AWS as the production platform for its cost efficiency, dedicat
 
 ### Dual Environment Design
 - **Local**: `docker-compose.yml` provides isolated development with bundled PostgreSQL
-- **Production (AWS)**: Terraform configuration in `terraform/aws-n8n/` deploys EC2 + RDS infrastructure
+- **Production (AWS)**: Terraform configuration in `.conductor/semarang/terraform/aws-n8n/` deploys EC2 + RDS infrastructure
 
 ### Configuration Strategy
 - Local uses hardcoded credentials in docker-compose.yml
@@ -51,7 +51,7 @@ docker-compose restart n8n
 ### AWS Production
 ```bash
 # Deploy infrastructure with Terraform
-cd terraform/aws-n8n
+cd .conductor/semarang/terraform/aws-n8n
 terraform init
 terraform plan
 terraform apply
@@ -92,7 +92,9 @@ AWS deployment configured for cost optimization (~$29/month):
 - URL: https://n8n.paulbonneville.com
 - Username: `admin`
 - Password: Configured in `/home/ubuntu/n8n/docker-compose.yml` on EC2 instance
-- SSH Access: `ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@44.253.69.204`
+- SSH Access: `ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip>`
+
+**Note**: The default local credentials (`admin`/`password`) should be changed in production. Update the password in the EC2 instance's docker-compose.yml file.
 
 ## Troubleshooting Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,25 +6,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is an n8n self-hosting setup supporting two deployment environments:
 - **Local development**: Docker Compose with PostgreSQL
-- **Production (Google Cloud Run)**: Google Cloud Run with Cloud SQL PostgreSQL (~$50/month optimized hosting)
+- **Production (AWS)**: AWS EC2 with RDS PostgreSQL (~$29/month optimized hosting)
 
-The project uses Google Cloud Run as the production platform for its scalability, cost optimization, and enterprise features.
+The project uses AWS as the production platform for its cost efficiency, dedicated resources, and Infrastructure as Code management via Terraform.
 
 ## Architecture
 
 ### Dual Environment Design
 - **Local**: `docker-compose.yml` provides isolated development with bundled PostgreSQL
-- **Production (Google Cloud Run)**: `cloud-run-deployment.yaml` deploys to Google Cloud Run with Cloud SQL database
+- **Production (AWS)**: Terraform configuration in `terraform/aws-n8n/` deploys EC2 + RDS infrastructure
 
 ### Configuration Strategy
 - Local uses hardcoded credentials in docker-compose.yml
-- Google Cloud Run uses environment variables with Cloud SQL database and Google Secret Manager
+- AWS production uses Terraform for infrastructure management
+- EC2 instance configured via user-data script with Docker Compose
+- Credentials managed via AWS Secrets Manager
 - Both environments use the same n8n image (`n8nio/n8n:latest`)
 
 ### Database Architecture
 - **Local**: PostgreSQL 14 container with persistent volumes
-- **Production (Google Cloud Run)**: Cloud SQL PostgreSQL database (connection via Cloud SQL Auth Proxy)
-- Configuration divergence handled through environment-specific files and templates
+- **Production (AWS)**: RDS PostgreSQL 14.13 (db.t4g.micro) with private VPC connection
+- Infrastructure defined in Terraform, deployed via `terraform apply`
 
 ## Common Commands
 
@@ -46,34 +48,38 @@ docker-compose down -v
 docker-compose restart n8n
 ```
 
-### Google Cloud Run Production
+### AWS Production
 ```bash
-# Deploy to Google Cloud Run
-./scripts/cloud-run-deploy.sh
+# Deploy infrastructure with Terraform
+cd terraform/aws-n8n
+terraform init
+terraform plan
+terraform apply
 
-# Monitor deployment status
-gcloud run services list --region=us-central1
+# SSH to EC2 instance
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip>
 
-# View service logs
-gcloud run logs read --service=n8n-app --region=us-central1
+# View n8n logs
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip> "docker logs n8n"
 
-# Update environment variables
-gcloud run services update n8n-app --region=us-central1 --update-env-vars="KEY=value"
+# Restart n8n
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip> "docker restart n8n"
 
-# Scale services (auto-scaling configured)
-gcloud run services update n8n-app --region=us-central1 --max-instances=10 --min-instances=1
+# Check RDS status
+aws rds describe-db-instances --region us-west-2 --db-instance-identifier n8n-db
 ```
 
 ## Key Configuration Points
 
-### Google Cloud Run Configuration
-Google Cloud Run deployment configured for cost optimization (~$50/month):
-- **Database**: Uses existing Cloud SQL PostgreSQL (35.225.58.181)
-- **n8n Service**: Cloud Run service with auto-scaling (1-10 instances)
-- **Resource allocation**: 2 CPU, 2GB RAM per instance
-- **Secrets**: Stored in Google Secret Manager
-- **Custom domain**: Configure via Cloud Run domain mappings
-- **SSL**: Automatically provisioned by Google
+### AWS Production Configuration
+AWS deployment configured for cost optimization (~$29/month):
+- **Compute**: EC2 t4g.small instance (ARM-based, 2 vCPU, 2GB RAM)
+- **Database**: RDS PostgreSQL 14.13 (db.t4g.micro)
+- **Region**: us-west-2 (Oregon)
+- **Reverse Proxy**: Caddy for automatic HTTPS
+- **Secrets**: AWS Secrets Manager for database credentials
+- **Custom domain**: n8n.paulbonneville.com (DNS A record to EC2 Elastic IP)
+- **SSL**: Automatically provisioned by Caddy
 
 ## Environment Access
 
@@ -82,10 +88,11 @@ Google Cloud Run deployment configured for cost optimization (~$50/month):
 - Username: `admin`
 - Password: `password`
 
-### Production Access (Google Cloud Run)
-- URL: https://n8n.paulbonneville.com (custom domain) or Cloud Run assigned URL
+### Production Access (AWS)
+- URL: https://n8n.paulbonneville.com
 - Username: `admin`
-- Password: Check Google Secret Manager for `n8n-basic-auth-password`
+- Password: Configured in `/home/ubuntu/n8n/docker-compose.yml` on EC2 instance
+- SSH Access: `ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@44.253.69.204`
 
 ## Troubleshooting Context
 
@@ -93,20 +100,22 @@ Google Cloud Run deployment configured for cost optimization (~$50/month):
 - Port 5678 conflicts: Modify `docker-compose.yml` ports section
 - Database connectivity: Ensure PostgreSQL container is healthy
 
-### Common Google Cloud Run Issues
-- Service startup failures: Check service logs with `gcloud run logs read --service=n8n-app`
-- Database connection errors: Verify Cloud SQL connectivity and Secret Manager configuration
-- Build failures: Ensure Docker image builds correctly for linux/amd64 platform
-- Environment variable issues: Check Secret Manager values and service configuration
+### Common AWS Production Issues
+- n8n not accessible: Check EC2 instance status and security group rules
+- Database connection errors: Verify RDS connectivity and credentials in docker-compose.yml
+- SSH access issues: Ensure using correct key (`~/.ssh/n8n-deploy-key.pem`) and security groups allow port 22
+- SSL certificate issues: Check Caddy logs with `ssh ubuntu@<ip> "sudo journalctl -u caddy"`
 
 ## Cost Considerations
 
-**Google Cloud Run deployment** cost-optimized hosting solution:
-- Estimated $50/month for production workload (reduced from $600/month)
-- Uses existing Cloud SQL database
-- Auto-scaling reduces costs during low usage
-- No VPC connector costs (direct database connection)
-- Enterprise features included (monitoring, logging, security)
+**AWS deployment** cost-optimized hosting solution:
+- Estimated $29/month for production workload
+  - EC2 t4g.small: ~$13/month
+  - RDS db.t4g.micro: ~$16/month
+- Single-cloud architecture (no cross-cloud egress charges)
+- ARM-based instances for better price/performance
+- 7-day automated RDS backups included
+- CloudWatch monitoring and logging included
 
 ## GitHub Actions & PR Standards
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # n8n Self-Hosted Setup
 
-This repository provides configurations for running n8n both locally (for development) and on Google Cloud Run (for production).
+This repository provides configurations for running n8n both locally (for development) and on AWS (for production).
 
 ## Overview
 
 n8n is a workflow automation tool that allows you to connect various services and automate tasks. This setup includes:
 - Local development environment with Docker Compose
-- Production deployment on Google Cloud Run with Cloud SQL database
+- Production deployment on AWS EC2 with AWS RDS PostgreSQL database
 - Persistent storage for workflows and credentials
-- Automated scripts for easy deployment
+- Infrastructure as Code with Terraform
 
 ## Prerequisites
 
@@ -17,11 +17,11 @@ n8n is a workflow automation tool that allows you to connect various services an
 - Docker Compose
 - 4GB RAM available
 
-### Production (Google Cloud Run)
-- Google Cloud account with billing enabled
-- `gcloud` CLI installed and authenticated
-- Docker installed
-- Existing Cloud SQL PostgreSQL database (optional)
+### Production (AWS)
+- AWS account with billing enabled
+- AWS CLI installed and configured
+- Terraform installed
+- SSH key pair for EC2 access
 
 ## Local Development
 
@@ -59,133 +59,126 @@ To remove all data:
 docker-compose down -v
 ```
 
-## Production Deployment (Google Cloud Run)
+## Production Deployment (AWS)
 
 ### Cost Estimate
-- **Monthly cost**: ~$30-55 (optimized setup)
-- Includes: Cloud Run service, Cloud SQL database, Secret Manager
-- Features: Auto-scaling, SSL certificates, monitoring
+- **Monthly cost**: ~$29 (optimized setup)
+- Includes: EC2 t4g.small instance, RDS db.t4g.micro PostgreSQL, backups
+- Features: Caddy reverse proxy with auto-SSL, CloudWatch monitoring
 
-### 🚀 Quick Deployment
+### 🚀 Quick Deployment with Terraform
 
-For a complete step-by-step migration guide, see: **[Cloud Run Migration Guide](docs/guides/CLOUD-RUN-MIGRATION.md)**
+See the complete Terraform configuration in `terraform/aws-n8n/`
 
-#### Configuration Setup
-1. **Copy environment template**
+#### Prerequisites
+1. **Set up AWS credentials**
    ```bash
-   cp .env.example .env
+   aws configure
    ```
 
-2. **Edit configuration** (required values)
+2. **Create Terraform variables**
    ```bash
-   # Edit .env with your specific values
-   PROJECT_ID=your-gcp-project-id
-   REGION=us-central1
-   # ... other variables
+   cd terraform/aws-n8n
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your values
    ```
 
-#### One-Command Setup
+#### Deploy Infrastructure
 ```bash
-# 1. Set up infrastructure
-./scripts/cloud-run-setup.sh
+cd terraform/aws-n8n
 
-# 2. Configure secrets (requires .env file)
-./scripts/cloud-run-secrets.sh
+# Initialize Terraform
+terraform init
 
-# 3. Deploy n8n
-./scripts/cloud-run-deploy.sh
+# Review planned changes
+terraform plan
+
+# Deploy infrastructure
+terraform apply
 ```
-
-**Note**: The deployment script automatically generates the final Cloud Run configuration from the template file using your environment variables. No manual configuration file editing is required.
 
 ### Production Features
-- **Auto-scaling**: 1-10 instances based on traffic
-- **High performance**: 2 CPU, 2GB RAM per instance
-- **Secure**: All credentials in Google Secret Manager
-- **SSL**: Automatic HTTPS with Google-managed certificates
-- **Monitoring**: Integrated Cloud Run monitoring and logging
-- **Cost-optimized**: Direct Cloud SQL connection (no VPC overhead)
+- **EC2 Instance**: ARM-based t4g.small for cost efficiency
+- **RDS Database**: PostgreSQL 14.13 with automated backups
+- **SSL/TLS**: Automatic HTTPS via Caddy reverse proxy
+- **Monitoring**: CloudWatch logs and metrics
+- **Backups**: Daily automated backups to S3 (optional)
+- **Security**: AWS Secrets Manager for credentials, IAM roles
 
 ### Custom Domain Setup
-See: **[DNS Update Guide](docs/guides/DNS-UPDATE-GUIDE.md)**
-
-```bash
-gcloud beta run domain-mappings create \
-  --service n8n-app \
-  --domain your-domain.com \
-  --region us-central1
-```
+The domain is configured automatically via Caddy. Update DNS to point to the EC2 instance Elastic IP.
 
 ## Project Structure
 
 ```
 arrgh-n8n/
 ├── docker-compose.yml                 # Local development setup
-├── Dockerfile.cloudrun                # Cloud Run optimized container
-├── cloud-run-deployment.template.yaml # Knative service template with env variables
 ├── .env.example                       # Environment variables template
-├── config/
-│   └── environments/                  # Environment-specific configurations
-│       ├── production.env            # Production defaults
-│       └── development.env           # Development defaults
-├── scripts/                           # Deployment automation
-│   ├── cloud-run-setup.sh            # Infrastructure setup
-│   ├── cloud-run-secrets.sh          # Secret Manager configuration
-│   ├── cloud-run-deploy.sh           # Build and deployment
-│   ├── generate-configs.sh           # Template processing utility
-│   └── monitor-domain.sh              # Domain migration monitoring
+├── terraform/
+│   └── aws-n8n/                       # AWS infrastructure as code
+│       ├── main.tf                    # Main Terraform configuration
+│       ├── variables.tf               # Input variables
+│       ├── outputs.tf                 # Output values
+│       ├── secrets.tf                 # AWS Secrets Manager config
+│       ├── user-data.sh               # EC2 bootstrap script
+│       └── terraform.tfvars.example   # Example variables file
 ├── docs/
-│   ├── guides/                        # Migration and setup guides
-│   └── audit/                         # Migration verification
+│   ├── guides/                        # Setup guides
+│   └── audit/                         # Infrastructure documentation
 ├── workflows/                         # n8n workflow backups
 └── README.md                          # This file
 ```
 
-## Configuration Architecture
+## Infrastructure as Code
 
-This deployment uses **environment variable substitution** for secure, flexible configuration:
+This deployment uses **Terraform** for infrastructure management:
 
-- **Template files** (`cloud-run-deployment.template.yaml`) contain variables like `${PROJECT_ID}`, `${REGION}`
-- **Environment files** (`.env`, `config/environments/*.env`) define actual values  
-- **Generated files** are created dynamically by `generate-configs.sh` during deployment
-- **Cloud Run** deploys using the generated Knative service definitions
+- **Terraform modules** define all AWS resources (EC2, RDS, security groups, IAM roles)
+- **Variable files** (`terraform.tfvars`) contain environment-specific values
+- **State management** tracks infrastructure changes
+- **User-data scripts** automate EC2 configuration with Docker Compose
 
 This approach ensures:
-✅ **No hardcoded credentials** in source control  
-✅ **Easy multi-environment deployments** (dev, staging, prod)  
-✅ **Secure secret management** via Google Secret Manager  
+✅ **No hardcoded credentials** in source control
+✅ **Reproducible infrastructure** across environments
+✅ **Secure secret management** via AWS Secrets Manager
+✅ **Version-controlled infrastructure** changes
 
-See the [Configuration Guide](docs/guides/CONFIGURATION-GUIDE.md) for complete setup instructions.
+See the Terraform configuration in `terraform/aws-n8n/` for details.
 
 ## Database Configuration
 
 This setup supports flexible database options:
 - **Local**: PostgreSQL container (development)
-- **Production**: Google Cloud SQL PostgreSQL
-- **Connection**: Direct public IP connection (cost-optimized)
-- **Security**: SSL/TLS encryption, Secret Manager for credentials
+- **Production**: AWS RDS PostgreSQL 14.13
+- **Connection**: Private VPC connection for security
+- **Security**: IAM authentication support, Secrets Manager for credentials
+- **Backups**: Automated daily backups with 7-day retention
 
 ## Security Considerations
 
-1. **Credentials**: All stored in Google Secret Manager
-2. **Network**: Direct SSL/TLS connection to Cloud SQL
-3. **Access**: Basic auth with strong passwords
-4. **Updates**: Latest n8n version (1.98.1)
-5. **Monitoring**: Cloud Run security scanning enabled
+1. **Credentials**: All stored in AWS Secrets Manager
+2. **Network**: Private VPC connection to RDS database
+3. **Access**: Basic auth with strong passwords, SSH key-based EC2 access
+4. **Updates**: Latest n8n version via Docker
+5. **Monitoring**: CloudWatch logs and metrics enabled
+6. **Encryption**: RDS encryption at rest (configurable)
 
-## Migration from Render/Other Platforms
+## Deployment Architecture
 
-This repository includes complete migration guides and automation:
+### Current Production Setup
+- **Platform**: AWS (us-west-2)
+- **Compute**: EC2 t4g.small instance (ARM-based)
+- **Database**: RDS PostgreSQL 14.13 (db.t4g.micro)
+- **Reverse Proxy**: Caddy (automatic HTTPS)
+- **Domain**: n8n.paulbonneville.com
 
-- **[Migration Guide](docs/guides/CLOUD-RUN-MIGRATION.md)** - Complete step-by-step process
-- **[Migration Success Report](docs/guides/migration-success.md)** - What to expect
-- **[Migration Audit](docs/audit/MIGRATION-AUDIT.md)** - Verification of scripts and processes
-
-### Migration Benefits
-- **Cost savings**: ~$553/month saved from original setup
-- **Better performance**: Dedicated resources, auto-scaling
-- **Enhanced monitoring**: Cloud Run native tools
-- **SSL included**: Google-managed certificates
+### Benefits
+- **Cost efficiency**: ~$29/month total infrastructure cost
+- **Performance**: Dedicated ARM-based instances
+- **Monitoring**: CloudWatch integration
+- **SSL/TLS**: Automatic certificate management via Caddy
+- **Backups**: Automated RDS backups with point-in-time recovery
 
 ## Troubleshooting
 
@@ -193,10 +186,10 @@ This repository includes complete migration guides and automation:
 - **Port 5678 in use**: Change port in docker-compose.yml
 - **Database connection failed**: Ensure PostgreSQL container is running
 
-### Cloud Run Issues
-- **Service not starting**: Check logs with `gcloud run logs read --service=n8n-app`
-- **Database connection failed**: Verify Cloud SQL credentials in Secret Manager
-- **Build failures**: Check Docker platform (must be linux/amd64)
+### AWS Issues
+- **Service not starting**: Check logs with `ssh ubuntu@<ip> "docker logs n8n"`
+- **Database connection failed**: Verify RDS credentials in AWS Secrets Manager
+- **EC2 access issues**: Ensure SSH key is configured and security groups allow access
 
 ### Common Commands
 
@@ -205,62 +198,69 @@ This repository includes complete migration guides and automation:
 docker-compose logs -f n8n           # View logs
 docker-compose restart n8n           # Restart n8n
 
-# Cloud Run
-gcloud run services list             # List services
-gcloud run logs read --service=n8n-app  # View logs
-gcloud run services describe n8n-app    # Service details
+# AWS Production
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip> "docker logs n8n"    # View logs
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip> "docker restart n8n" # Restart n8n
+aws rds describe-db-instances --region us-west-2                       # Check RDS status
 ```
 
 ## Cost Optimization
 
 This setup is optimized for cost efficiency:
 
-1. **No VPC Connector**: Direct Cloud SQL connection saves ~$518/month
-2. **Right-sized resources**: 2 CPU, 2GB RAM for optimal performance
-3. **Auto-scaling**: Pay only for what you use
-4. **Shared infrastructure**: Reuse existing Cloud SQL databases
+1. **ARM-based instances**: t4g instances offer better price/performance
+2. **Right-sized resources**: t4g.small EC2, db.t4g.micro RDS
+3. **Single-cloud architecture**: All resources in AWS (no cross-cloud egress)
+4. **Automated backups**: 7-day RDS backup retention included
 
 ## Monitoring & Maintenance
 
 ### Performance Monitoring
 ```bash
 # Check service health
-gcloud run services describe n8n-app --region=us-central1
+curl https://n8n.paulbonneville.com/healthz
 
-# Monitor resource usage
-# Visit Google Cloud Console > Cloud Run > n8n-app > Metrics
+# Monitor resource usage via AWS CloudWatch
+aws cloudwatch get-metric-statistics --namespace N8N --region us-west-2
+
+# View EC2 metrics in AWS Console
 ```
 
 ### Updates
 ```bash
-# Update to latest n8n version
-./scripts/cloud-run-deploy.sh
+# SSH to EC2 instance
+ssh -i ~/.ssh/n8n-deploy-key.pem ubuntu@<ec2-ip>
+
+# Pull latest n8n image and restart
+cd /home/ubuntu/n8n
+docker-compose pull
+docker-compose up -d
 ```
 
 ## Next Steps
 
-1. **Deploy**: Follow the [Migration Guide](docs/guides/CLOUD-RUN-MIGRATION.md)
-2. **Custom Domain**: Configure your domain with [DNS Guide](docs/guides/DNS-UPDATE-GUIDE.md)
+1. **Deploy**: Use Terraform in `terraform/aws-n8n/` directory
+2. **Custom Domain**: Update DNS A record to point to EC2 Elastic IP
 3. **Import Workflows**: Use the n8n API or web interface
-4. **Set up Monitoring**: Configure Cloud Run alerts
-5. **Cost Monitoring**: Set up billing alerts
+4. **Set up Monitoring**: Configure CloudWatch alarms
+5. **Cost Monitoring**: Set up AWS billing alerts
 
 ## Resources
 
 - [n8n Documentation](https://docs.n8n.io/)
-- [Google Cloud Run Documentation](https://cloud.google.com/run/docs)
-- [Cloud SQL Documentation](https://cloud.google.com/sql/docs)
-- [Migration Guides](docs/guides/)
+- [AWS EC2 Documentation](https://docs.aws.amazon.com/ec2/)
+- [AWS RDS Documentation](https://docs.aws.amazon.com/rds/)
+- [Terraform AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 
 ## Support
 
 For issues with:
 - **n8n**: Visit [n8n Community](https://community.n8n.io/)
-- **Google Cloud**: Check [Cloud Support](https://cloud.google.com/support)
-- **This setup**: Check the [guides](docs/guides/) or open an issue
+- **AWS**: Check [AWS Support](https://aws.amazon.com/support/)
+- **Terraform**: See [Terraform Documentation](https://www.terraform.io/docs)
 
 ---
 
-**Current Status**: ✅ Production ready on Google Cloud Run  
-**Last Updated**: July 2025  
-**Migration**: Successfully completed from Render.com
+**Current Status**: ✅ Production ready on AWS (us-west-2)
+**Last Updated**: October 2025
+**Platform**: AWS EC2 + RDS

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ n8n is a workflow automation tool that allows you to connect various services an
    - Username: `admin`
    - Password: `password`
 
+   **Security Warning**: These are development-only credentials. Change them before exposing to any network.
+
 ### Local Features
 - PostgreSQL database included
 - Data persists between restarts
@@ -78,14 +80,14 @@ See the complete Terraform configuration in `terraform/aws-n8n/`
 
 2. **Create Terraform variables**
    ```bash
-   cd terraform/aws-n8n
+   cd .conductor/semarang/terraform/aws-n8n
    cp terraform.tfvars.example terraform.tfvars
    # Edit terraform.tfvars with your values
    ```
 
 #### Deploy Infrastructure
 ```bash
-cd terraform/aws-n8n
+cd .conductor/semarang/terraform/aws-n8n
 
 # Initialize Terraform
 terraform init
@@ -114,14 +116,16 @@ The domain is configured automatically via Caddy. Update DNS to point to the EC2
 arrgh-n8n/
 ├── docker-compose.yml                 # Local development setup
 ├── .env.example                       # Environment variables template
-├── terraform/
-│   └── aws-n8n/                       # AWS infrastructure as code
-│       ├── main.tf                    # Main Terraform configuration
-│       ├── variables.tf               # Input variables
-│       ├── outputs.tf                 # Output values
-│       ├── secrets.tf                 # AWS Secrets Manager config
-│       ├── user-data.sh               # EC2 bootstrap script
-│       └── terraform.tfvars.example   # Example variables file
+├── .conductor/
+│   └── semarang/
+│       └── terraform/
+│           └── aws-n8n/               # AWS infrastructure as code
+│               ├── main.tf            # Main Terraform configuration
+│               ├── variables.tf       # Input variables
+│               ├── outputs.tf         # Output values
+│               ├── secrets.tf         # AWS Secrets Manager config
+│               ├── user-data.sh       # EC2 bootstrap script
+│               └── terraform.tfvars.example
 ├── docs/
 │   ├── guides/                        # Setup guides
 │   └── audit/                         # Infrastructure documentation
@@ -144,7 +148,7 @@ This approach ensures:
 ✅ **Secure secret management** via AWS Secrets Manager
 ✅ **Version-controlled infrastructure** changes
 
-See the Terraform configuration in `terraform/aws-n8n/` for details.
+See the Terraform configuration in `.conductor/semarang/terraform/aws-n8n/` for details.
 
 ## Database Configuration
 
@@ -239,7 +243,7 @@ docker-compose up -d
 
 ## Next Steps
 
-1. **Deploy**: Use Terraform in `terraform/aws-n8n/` directory
+1. **Deploy**: Use Terraform in `.conductor/semarang/terraform/aws-n8n/` directory
 2. **Custom Domain**: Update DNS A record to point to EC2 Elastic IP
 3. **Import Workflows**: Use the n8n API or web interface
 4. **Set up Monitoring**: Configure CloudWatch alarms


### PR DESCRIPTION
## Summary
Cleaned up infrastructure after confirming n8n migration to AWS RDS is complete. The migration was actually completed on Oct 25, 2025 when Claude Code deployed the infrastructure.

## Changes
- ✅ Deleted unused GCP Cloud SQL instance
- ✅ Updated README.md to reflect AWS infrastructure (EC2 + RDS)
- ✅ Updated CLAUDE.md with AWS commands and configuration
- ✅ Removed investigation files that were used to analyze the infrastructure

## Infrastructure
- **EC2**: t4g.small instance (us-west-2)
- **RDS**: PostgreSQL 14.13 (db.t4g.micro)
- **Domain**: n8n.paulbonneville.com
- **SSL**: Caddy reverse proxy

## Cost Impact
- **Before**: ~$46-56/month (AWS + unused GCP Cloud SQL)
- **After**: ~$29/month (AWS only)
- **Savings**: $17-27/month ($204-324/year)

## Testing
- [x] Verified n8n is healthy: `curl https://n8n.paulbonneville.com/healthz`
- [x] Verified database connection to AWS RDS
- [x] Verified workflows are accessible via MCP servers
- [x] Confirmed GCP Cloud SQL was unused before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)